### PR TITLE
QUIT und Verbindungsabbrüche werden korrekt behandelt

### DIFF
--- a/src/Client.hs
+++ b/src/Client.hs
@@ -21,6 +21,7 @@ buildMsg :: User -> Msg -> String
 buildMsg user (PrivMsg receiver msg) = ":" ++ toString user ++ " PRIVMSG " ++ receiver ++ " :" ++ msg
 buildMsg user (Join channel) = ":" ++ toString user ++ " JOIN " ++ channel
 buildMsg user (Part channel msg) = ":" ++ toString user ++ " PART " ++ channel ++ " :" ++ msg
+buildMsg user (Quit msg) = ":" ++ toString user ++ " QUIT :" ++ msg
 
 parseMsg :: String -> Msg
 parseMsg str = parseCommand cmd after

--- a/src/Client.hs
+++ b/src/Client.hs
@@ -14,6 +14,7 @@ data Msg = Plain String
         | Join String
         | Part String String
         | Ping String
+        | Quit String
     deriving (Show, Eq)
 
 buildMsg :: User -> Msg -> String
@@ -38,4 +39,6 @@ parseCommand "PART " after
         | otherwise = Part after ""
         where (_, _, msg, groups) = after =~ "^(\\S+)\\s:" :: (String, String, String, [String])
 parseCommand "PING " server = Ping server
+parseCommand "QUIT " after = Quit msg
+        where msg = tail after
 parseCommand cmd after = Plain (cmd ++ after)

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -73,9 +73,12 @@ handleEvent users channels (ClientMsg user@(FullUser nick _ _) msg@(Part channel
     let new_channels = Map.insert channel (filter ((/=) nick) members) channels
     return (users, new_channels)
 handleEvent users channels (ClientMsg user@(FullUser nick _ _) msg@(Quit _)) = do
-    print "Closing connection"
-    hClose (users ! nick)
-    return (users , channels)
+    let hdl = users ! nick
+        new_users = Map.delete nick users
+        new_channels = Map.map (filter (nick /=)) channels
+    hClose hdl
+    sendToAllUsers users (Map.keys new_users) (buildMsg user msg)
+    return (new_users , new_channels)
 handleEvent users channels _ = do
     return (users, channels)
 


### PR DESCRIPTION
Wenn ein Client eine QUIT-Nachricht schickt oder die Verbindung abbricht, wird der Nickname aus allen Datenstrukturen entfernt und die anderen Clients darüber benachrichtigt.

Closes #15 